### PR TITLE
No openai config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"onCreateCommand": "pip install -U pip uv; uv venv; source .venv/bin/activate; uv pip install --extra-index-url https://europe-west3-python.pkg.dev/rasa-releases/rasa-pro-python/simple rasa-pro==3.10.0 seaborn==0.13.2 jupyter==1.0.0 --prerelease=allow",
+	"onCreateCommand": "pip install -U pip uv; uv venv; source .venv/bin/activate; uv pip install --extra-index-url https://europe-west3-python.pkg.dev/rasa-releases/rasa-pro-python/simple rasa-sdk==3.11.0rc1 rasa-pro==3.11.0rc1 seaborn==0.13.2 jupyter==1.0.0; uv pip install openai==1.55.3",
 
 	// Configure tool-specific properties.
 	"customizations": {

--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
-# CALM Reimplementation of LangGraph's customer service bot
+# CALM Reimplementation of LangGraph's customer service bot without OpenAI models
 
-This is a reimplementation of langgraph's [customer support](https://langchain-ai.github.io/langgraph/tutorials/customer-support/customer-support/) example in Rasa's [CALM](https://rasa.com/docs/rasa-pro/calm/) paradigm 
-There's a [YouTube video](https://www.youtube.com/watch?v=b3XsvoFWp4c) that provides a walkthrough of langgraph's implementation. 
+This branch includes instructions for running [CALM Reimplementation of LangGraph's customer service bot](https://github.com/RasaHQ/calm-langgraph-customer-service-comparison) without utilizing OpenAI models.
+
+## Why consider using custom LLM models?
+
+- **Cost-effectiveness**
+By default, CALM uses OpenAI models for powering LLM-based components like the Command Generator and Contextual Response Rephraser. While powerful OpenAI models provide great performance results, they can be quite costly when running assistants in production. The modular nature of CALM enables developers to use smaller, more cost-effective models that can be fine-tuned for specific tasks. Often, these models provide great performance results while keeping the cost low.
+  
+- **Customization and availability**
+By using custom, open-source LLMs, developers can avoid vendor lock-in and rate limits imposed by third-party LLM providers.
 
 
 ## Skills
@@ -19,26 +26,19 @@ Follow these steps to set up and run the Rasa assistant in a GitHub Codespace.
 
 ### Prerequisites
 
-- You'll need a [Rasa Pro license](https://rasa.com/docs/rasa-pro/installation/python/licensing/) and an [OpenAI API key](https://platform.openai.com/api-keys).
+- You'll need a [Rasa Pro license](https://rasa.com/docs/rasa-pro/installation/python/licensing/).
 - You should be familiar with Python and Bash.
 
 ### Steps to run the CALM assistant
-
-
-To run the CALM assistant, you can watch the video below and/or follow the instructions:
-
-https://github.com/user-attachments/assets/45a828fe-b638-4d5f-8d55-22a831d5f198
-
-
 
 1. **Create a Codespace:**
 
    - Navigate to the repository on GitHub.
    - Click on the green "Code" button, then scroll down to "Codespaces".
-   - Click on "Create codespace on main branch".
+   - Click on "Create codespace on no-openai-config branch".
    - This should take under two minutes to load.
 
-  ![Screenshot 2024-08-05 at 11 01 26 AM](https://github.com/user-attachments/assets/0795f628-afb5-4d26-980a-807a2805169b)
+  
 
 
 2. **Set Up Environment:**
@@ -48,7 +48,6 @@ https://github.com/user-attachments/assets/45a828fe-b638-4d5f-8d55-22a831d5f198
    - Open `/calm_llm/.env` file and add the required keys to that file.
      ```
      export RASA_PRO_LICENSE='your_rasa_pro_license_key_here'
-     export OPENAI_API_KEY='your_openai_api_key_here'
      ```
    - In both terminals, set your environment variables by running:
      ```

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Follow these steps to set up and run the Rasa assistant in a GitHub Codespace.
 
 ### Steps to run the CALM assistant
 
+This guide will show how you can run the CALM assistant that is configured to use Rasa's fine-tuned [CodeLlama 13B](https://huggingface.co/rasa/cmd_gen_codellama_13b_calm_demo) model instead of the OpenAI models. If you'd like to see an example of the same implementation using OpenAI models, switch to the `main` branch.
+
 1. **Create a Codespace:**
 
    - Navigate to the repository on GitHub.
@@ -87,8 +89,8 @@ Follow these steps to set up and run the Rasa assistant in a GitHub Codespace.
 
 - Keyboard bindings may not map correctly in the Codespace, so you may not be able to copy and paste as you normally would!
 - The database creation is done separately to manage memory usage.
-- The repository is compatible with Rasa Pro versions `>=3.10.0`.
-- You'll also notice that there are several subdirectories: `calm_llm` is the CALM implementation, `calm_nlu` combines CALM with intent based NLU, `langgraph_implementation` is the implementation inspired from [langgraph's tutorial](https://langchain-ai.github.io/langgraph/tutorials/customer-support/customer-support/), `calm_self_hosted` is the CALM implementation but a fine-tuned model such as Llama 3.1 8B working as the command generator, and `calm_nlu_self_hosted` is CALM working with intent based NLU and a fine-tuned model as the command generator.
+- The repository is compatible with Rasa Pro versions `>=3.11.0rc1`.
+- You'll also notice that there are several subdirectories: `calm_llm` is the CALM implementation with fine-tuned model, `calm_nlu` combines CALM with intent based NLU, `langgraph_implementation` is the implementation inspired from [langgraph's tutorial](https://langchain-ai.github.io/langgraph/tutorials/customer-support/customer-support/), `calm_self_hosted` is the CALM implementation but a fine-tuned model such as Llama 3.1 8B working as the command generator, and `calm_nlu_self_hosted` is CALM working with intent based NLU and a fine-tuned model as the command generator.
 
 ## Quantitative Evaluation
 

--- a/calm_llm/config.yml
+++ b/calm_llm/config.yml
@@ -1,15 +1,13 @@
 recipe: default.v1
 language: en
 pipeline:
-- name: custom.custom_cmd_gen.CustomLLMCommandGenerator
+- name: SingleStepLLMCommandGenerator
   llm:
-    provider: openai
-    model: gpt-4-0613
-    timeout: 7
-    max_tokens: 256
-    temperature: 0
-    cache:
-      no-cache: true
+    provider: rasa
+    model: rasa/cmd_gen_codellama_13b_calm_demo
+    api_base: "https://tutorial-llm.rasa.ai"
+  flow_retrieval:
+    active: false
   prompt_template: prompt_templates/time_aware_prompt.jinja2
 
 policies:

--- a/calm_llm/data/flows/utils.yml
+++ b/calm_llm/data/flows/utils.yml
@@ -7,19 +7,6 @@ flows:
     description: tell the user what i can do
     steps:
       - action: utter_skills
-  pattern_completed:
-    description: trigger when all flows are completed
-    steps:
-      - noop: true
-        next:
-          - if: context.previous_flow_name = "goodbye"
-            then: listen
-          - else: ask_what
-      - id: listen
-        action: action_listen
-        next: END
-      - id: ask_what
-        action: utter_else
   pattern_cannot_handle:
     description: when you dont understand the user
     steps:

--- a/calm_llm/endpoints.yml
+++ b/calm_llm/endpoints.yml
@@ -42,5 +42,9 @@ action_endpoint:
 #  queue: queue
 #
 nlg:
- type: custom.quick_rephraser.QuickResponseRephraser
- prompt: prompt_templates/rephrase_prompt.jinja2
+  type: rephrase
+  llm:
+    provider: rasa
+    model: rasa/cmd_gen_codellama_13b_calm_demo
+    api_base: "https://tutorial-llm.rasa.ai"
+  prompt: prompt_templates/rephrase_prompt.jinja2


### PR DESCRIPTION
### Do not merge.

This is an updated version of the calm_llm bot to use non-openai models. This setup should automatically setup the environment with rasa-pro 3.11.0rc1 which supports the configuration of rasa hosted endpoint.